### PR TITLE
Add manual stock input on product creation

### DIFF
--- a/Stationary/Views/Admin/Create.cshtml
+++ b/Stationary/Views/Admin/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@model Stationary.Models.Product
+@model Stationary.Models.Product
 
 <!-- Best way: use link tag for Google Fonts -->
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
@@ -266,6 +266,16 @@
             <div class="form-group">
                 @Html.TextBoxFor(m => m.Price, new { @class = "form-control", placeholder = " ", type = "number", step = "0.01", min = "0", required = "required" })
                 <label class="form-label">Price ($)</label>
+            </div>
+
+            <div class="form-group">
+                @Html.TextBoxFor(m => m.StockQuantity, new { @class = "form-control", placeholder = " ", type = "number", step = "1", min = "0", required = "required" })
+                <label class="form-label">Stock Quantity</label>
+            </div>
+
+            <div class="form-group">
+                @Html.TextBoxFor(m => m.LowStockThreshold, new { @class = "form-control", placeholder = " ", type = "number", step = "1", min = "0" })
+                <label class="form-label">Low Stock Threshold (Optional)</label>
             </div>
 
             <div class="form-group">


### PR DESCRIPTION
Add Stock Quantity and Low Stock Threshold fields to the product creation form.

This allows users to manually input stock quantity and a low stock threshold when creating a new product, making the creation process consistent with the product editing functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-2774b04b-610b-42e5-a631-e2a1e5d6043d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2774b04b-610b-42e5-a631-e2a1e5d6043d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

